### PR TITLE
Potential fix for code scanning alert no. 11: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/untar.go
+++ b/untar.go
@@ -40,7 +40,12 @@ func Untar(dst string, r io.Reader) error {
 		}
 
 		// the target location where the dir/file should be created
-		target := filepath.Join(dst, header.Name)
+		// Clean the path and ensure it is within the destination directory
+		cleanedPath := filepath.Clean(header.Name)
+		if strings.Contains(cleanedPath, "..") {
+			return fmt.Errorf("invalid file path: %s", cleanedPath)
+		}
+		target := filepath.Join(dst, cleanedPath)
 
 		// the following switch could also be done using fi.Mode(), not sure if there
 		// a benefit of using one vs. the other.


### PR DESCRIPTION
Potential fix for [https://github.com/cmd184psu/alfredo/security/code-scanning/11](https://github.com/cmd184psu/alfredo/security/code-scanning/11)

To fix the problem, we need to ensure that the paths constructed from tar archive entries do not contain any directory traversal elements like `..`. This can be achieved by validating the `header.Name` before using it to construct the target path. Specifically, we should check that the path does not contain `..` and is within the intended destination directory.

The best way to fix the problem without changing existing functionality is to:
1. Use `filepath.Clean` to clean the path.
2. Ensure that the cleaned path is within the destination directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
