### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/aws-s3.go
+++ b/aws-s3.go
@@ -197,7 +197,7 @@ func (s3c *S3ClientSession) EstablishSession() error {
 		//		return errors.New("missing region")
 	}
 
-	VerbosePrintf("!!! ep:%s, ak/sk: %s/%s, fps: %s, r: %s", s3c.Endpoint, s3c.Credentials.AccessKey, s3c.Credentials.SecretKey, TrueIsYes(true), s3c.Region)
+	VerbosePrintf("!!! ep:%s, ak: %s, fps: %s, r: %s", s3c.Endpoint, s3c.Credentials.AccessKey, TrueIsYes(true), s3c.Region)
 
 	awsConfig := aws.NewConfig().
 		WithEndpoint(s3c.Endpoint).


### PR DESCRIPTION
Potential fix for [https://github.com/cmd184psu/alfredo/security/code-scanning/5](https://github.com/cmd184psu/alfredo/security/code-scanning/5)

To fix the problem, we need to ensure that sensitive information such as `s3c.Credentials.SecretKey` is not logged in clear text. Instead, we should either obfuscate the sensitive information or omit it entirely from the logs. The best way to fix this without changing existing functionality is to modify the `VerbosePrintf` function call in `aws-s3.go` to exclude the sensitive information and update the `VerbosePrintln` function in `util.go` to handle the modified input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
